### PR TITLE
fix: gas price in details response

### DIFF
--- a/packages/relayer/README.md
+++ b/packages/relayer/README.md
@@ -74,6 +74,7 @@ Each entry in the `chains` array configures support for a specific blockchain:
 | `fee_receiver_address` | Address (optional) | Chain-specific fee receiver address (overrides defaults) |
 | `signer_private_key` | Private Key (optional) | Chain-specific signer private key (overrides defaults) |
 | `entrypoint_address` | Address (optional) | Chain-specific entrypoint address (overrides defaults) |
+| `max_gas_price` | String/Number (optional) | Max gas price for accepting relay operations, in WEI |
 | `native_currency` | Object | Information about the chain's native currency |
 | `supported_assets` | Array | List of supported assets on this chain |
 

--- a/packages/relayer/config.example.json
+++ b/packages/relayer/config.example.json
@@ -9,7 +9,7 @@
             "chain_id": "31337",
             "chain_name": "localhost",
             "rpc_url": "http://0.0.0.0:8545",
-            "max_gas_price": "0x12345",
+            "max_gas_price": "2392000000",
             "native_currency": {
                 "name": "Ether",
                 "symbol": "ETH",
@@ -31,7 +31,7 @@
             "fee_receiver_address": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
             "signer_private_key": "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
             "entrypoint_address": "0xa513e6e4b8f2a923d98304ec87f64353c4d5c853",
-            "max_gas_price": "0x12345",
+            "max_gas_price": "2392000000",
             "native_currency": {
                 "name": "Sepolia Ether",
                 "symbol": "ETH",

--- a/packages/relayer/src/handlers/relayer/details.ts
+++ b/packages/relayer/src/handlers/relayer/details.ts
@@ -70,7 +70,8 @@ export function relayerDetailsHandler(
         getAddress(feeReceiverAddress) as Address,
         chainId,
         normalizedAssetAddress as Address,
-        assetConfig.min_withdraw_amount
+        assetConfig.min_withdraw_amount,
+        chainConfig.max_gas_price,
       )
     )
   );

--- a/packages/relayer/src/handlers/relayer/details.ts
+++ b/packages/relayer/src/handlers/relayer/details.ts
@@ -60,7 +60,7 @@ export function relayerDetailsHandler(
         feeBPS: assetConfig.fee_bps,
         feeReceiverAddress: getAddress(feeReceiverAddress),
         chainId,
-        chainConfig.max_gas_price,
+        maxGasPrice: chainConfig.max_gas_price,
         assetAddress: normalizedAssetAddress as Address,
         minWithdrawAmount: assetConfig.min_withdraw_amount
       })

--- a/packages/relayer/src/types.ts
+++ b/packages/relayer/src/types.ts
@@ -17,7 +17,7 @@ export class DetailsMarshall extends RelayerMarshall {
     super();
   }
   override toJSON(): object {
-    const result: Record<string, string | number | undefined> = {
+    const result: Record<string, string | number | undefined | null> = {
       feeBPS: this.feeBPS.toString(),
       feeReceiverAddress: this.feeReceiverAddress.toString(),
     };
@@ -38,7 +38,7 @@ export class DetailsMarshall extends RelayerMarshall {
       result.maxGasPrice = this.maxGasPrice.toString(10);
     }
     else {
-      result.maxGasPrice = "0";
+      result.maxGasPrice = null;
     }
     
     return result;

--- a/packages/relayer/src/types.ts
+++ b/packages/relayer/src/types.ts
@@ -6,42 +6,34 @@ export abstract class RelayerMarshall {
 }
 
 export class DetailsMarshall extends RelayerMarshall {
-  constructor(
-    private feeBPS: bigint,
-    private feeReceiverAddress: Address,
-    private chainId?: number,
-    private assetAddress?: Address,
-    private minWithdrawAmount?: bigint,
-    private maxGasPrice?: bigint,
-  ) {
+  constructor(private details: {
+    feeBPS: bigint,
+    feeReceiverAddress: Address,
+    chainId?: number,
+    assetAddress?: Address,
+    minWithdrawAmount?: bigint,
+    maxGasPrice?: bigint,
+  }) {
     super();
   }
   override toJSON(): object {
-    const result: Record<string, string | number | undefined | null> = {
-      feeBPS: this.feeBPS.toString(),
-      feeReceiverAddress: this.feeReceiverAddress.toString(),
-    };
-    
-    if (this.chainId !== undefined) {
-      result.chainId = this.chainId;
-    }
-    
-    if (this.assetAddress !== undefined) {
-      result.assetAddress = this.assetAddress.toString();
-    }
-    
-    if (this.minWithdrawAmount !== undefined) {
-      result.minWithdrawAmount = this.minWithdrawAmount.toString();
-    }
-    
-    if (this.maxGasPrice !== undefined) {
-      result.maxGasPrice = this.maxGasPrice.toString(10);
+
+    let maxGasPrice: string | null;
+    if (this.details.maxGasPrice !== undefined) {
+      maxGasPrice = this.details.maxGasPrice.toString(10);
     }
     else {
-      result.maxGasPrice = null;
+      maxGasPrice = null;
     }
-    
-    return result;
+
+    return {
+      feeBPS: this.details.feeBPS.toString(),
+      feeReceiverAddress: this.details.feeReceiverAddress.toString(),
+      chainId: this.details.chainId,
+      assetAddress: this.details.assetAddress?.toString(),
+      minWithdrawAmount: this.details.minWithdrawAmount?.toString(),
+      maxGasPrice
+    };
   }
 }
 

--- a/packages/relayer/src/types.ts
+++ b/packages/relayer/src/types.ts
@@ -12,6 +12,7 @@ export class DetailsMarshall extends RelayerMarshall {
     private chainId?: number,
     private assetAddress?: Address,
     private minWithdrawAmount?: bigint,
+    private maxGasPrice?: bigint,
   ) {
     super();
   }
@@ -31,6 +32,13 @@ export class DetailsMarshall extends RelayerMarshall {
     
     if (this.minWithdrawAmount !== undefined) {
       result.minWithdrawAmount = this.minWithdrawAmount.toString();
+    }
+    
+    if (this.maxGasPrice !== undefined) {
+      result.maxGasPrice = this.maxGasPrice.toString(10);
+    }
+    else {
+      result.maxGasPrice = "0";
     }
     
     return result;


### PR DESCRIPTION
Added the missing parameter to the details response. If not defined for the chain then it will return a `null`, signaling no limit.

Additionally edited the config example to show clearer `max_gas_price` values in WEI.