### PR TITLE
fix(sdk): remove RPC apiKey config from Data Service

### DIFF
--- a/packages/sdk/src/core/data.service.ts
+++ b/packages/sdk/src/core/data.service.ts
@@ -45,13 +45,12 @@ export class DataService {
 
     try {
       for (const config of chainConfigs) {
-        if (!config.rpcUrl || !config.apiKey) {
-          throw new Error(`Missing RPC URL or API key for chain ${config.chainId}`);
+        if (!config.rpcUrl) {
+          throw new Error(`Missing RPC URL for chain ${config.chainId}`);
         }
 
         const client = createPublicClient({
           transport: http(config.rpcUrl),
-          key: config.apiKey,
         });
         this.clients.set(config.chainId, client);
       }

--- a/packages/sdk/src/types/events.ts
+++ b/packages/sdk/src/types/events.ts
@@ -45,7 +45,6 @@ export interface ChainConfig {
   privacyPoolAddress: Address;
   startBlock: bigint;
   rpcUrl: string;
-  apiKey: string;  // API key for RPC provider authentication
 }
 
 /**

--- a/packages/sdk/test/unit/data.service.spec.ts
+++ b/packages/sdk/test/unit/data.service.spec.ts
@@ -28,17 +28,11 @@ describe('DataService with Sepolia', () => {
   };
 
   beforeAll(() => {
-    const apiKey = process.env.RPC_API_KEY;
-    if (!apiKey) {
-      throw new Error('RPC_API_KEY environment variable is required');
-    }
-
     const config: ChainConfig = {
       chainId: SEPOLIA_CHAIN_ID,
       privacyPoolAddress: POOL_ADDRESS,
       startBlock: START_BLOCK,
       rpcUrl: 'https://sepolia.rpc.hypersync.xyz',
-      apiKey,
     };
 
     dataService = new DataService([config]);


### PR DESCRIPTION
## Description

Remove `apiKey` for RPC from DataService as it's not required -`key` from Viem is actually an identifier for the client, not the key for the RPC (https://viem.sh/docs/clients/public#key-optional) 