### PR TITLE
bumped lean-imt version for SDK

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@types/snarkjs": "0.7.9",
-    "@zk-kit/lean-imt": "2.2.2",
+    "@zk-kit/lean-imt": "2.2.4",
     "maci-crypto": "2.5.0",
     "snarkjs": "0.7.5",
     "typescript": "^5.7.3",


### PR DESCRIPTION
[v2.2.4](https://github.com/zk-kit/zk-kit/releases/tag/lean-imt-v2.2.4) of lean-imt includes the fix which fixes the error on zk proof generation when only 0 or 1 deposits were maid in the pool