### PR TITLE
fix(sdk): fix for duplicated precommitments

### DIFF
--- a/packages/sdk/src/core/account.service.ts
+++ b/packages/sdk/src/core/account.service.ts
@@ -488,7 +488,12 @@ export class AccountService {
 
       const depositMap = new Map<Hash, DepositEvent>();
       for (const event of depositEvents) {
-        depositMap.set(event.precommitment, event);
+        const existingEvent = depositMap.get(event.precommitment);
+
+        // If no existing event, or current event is older (earlier block), use current event
+        if (!existingEvent || event.blockNumber < existingEvent.blockNumber) {
+          depositMap.set(event.precommitment, event);
+        }
       }
 
       return depositMap;


### PR DESCRIPTION
There is an issue when user whos commitment was nullified due to entrypoint upgrade decrypts incorrect label with the same precommitment, which leads to fetching incorrect status from ASP. This PR introduces logic for checking if theres another precommitment with earlier block number to use this one instead.

test of this will be covered after #105 is merged