### PR TITLE
fix: validate fee commitment matches withdrawal data

### DIFF
--- a/packages/relayer/src/services/privacyPoolRelayer.service.ts
+++ b/packages/relayer/src/services/privacyPoolRelayer.service.ts
@@ -310,6 +310,13 @@ export class PrivacyPoolRelayer {
         );
       }
 
+      // Verify the fee commitment was generated for this exact withdrawal data
+      if (wp.feeCommitment.withdrawalData !== wp.withdrawal.data) {
+        throw WithdrawalValidationError.relayerCommitmentRejected(
+          `Fee commitment withdrawal data mismatch: commitment was generated for different withdrawal parameters`,
+        );
+      }
+
     } else {
 
       const currentFeeBPS = await quoteService.quoteFeeBPSNative({


### PR DESCRIPTION
Add defense-in-depth check to ensure the feeCommitment.withdrawalData matches the actual withdrawal.data being submitted. This prevents a stale fee commitment (quoted for a different amount) from being used with a different withdrawal, which could result in incorrect fees.

The frontend had a bug where typing an amount character by character would not refetch the quote, causing mismatched fee commitments. This server-side check ensures such mismatches are rejected.