### PR TITLE
Fixed 0 values withdrawals processing in SDK

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2026-03-08
+
+### Fixed
+
+- Fixed 0n value withdrawals processing in the SDK
+
 ## [1.1.0] - 2026-02-19
 
 ### Added

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xbow/privacy-pools-core-sdk",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Typescript SDK for the Privacy Pool protocol",
   "repository": "https://github.com/0xbow-io/privacy-pools-core",
   "license": "Apache-2.0",

--- a/packages/sdk/src/core/data.service.ts
+++ b/packages/sdk/src/core/data.service.ts
@@ -253,7 +253,8 @@ export class DataService {
           } = typedLog.args;
 
           if (
-            !value ||
+            value === undefined ||
+            value === null ||
             !spentNullifier ||
             !newCommitment ||
             !typedLog.blockNumber ||


### PR DESCRIPTION
Self-relayed withdrawals were possible to have zero withdrawal value. This caused SDK to throw an error because 0 was interpreted as a falsy value. This PR fixes withdrawal value check.