### PR TITLE
fix(sdk): read pool state root from currentRoot

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.1.2] - 2026-03-09
+## [1.2.1] - 2026-03-09
 
 ### Fixed
 

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.2] - 2026-03-09
+
+### Fixed
+
+- Fixed `getStateRoot()` to read `currentRoot()` from the privacy pool contract
+
 ## [1.1.1] - 2026-03-08
 
 ### Fixed

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xbow/privacy-pools-core-sdk",
-  "version": "1.1.2",
+  "version": "1.2.1",
   "description": "Typescript SDK for the Privacy Pool protocol",
   "repository": "https://github.com/0xbow-io/privacy-pools-core",
   "license": "Apache-2.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xbow/privacy-pools-core-sdk",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Typescript SDK for the Privacy Pool protocol",
   "repository": "https://github.com/0xbow-io/privacy-pools-core",
   "license": "Apache-2.0",

--- a/packages/sdk/src/core/contracts.service.ts
+++ b/packages/sdk/src/core/contracts.service.ts
@@ -250,17 +250,17 @@ export class ContractInteractionsService implements ContractInteractions {
   }
 
   /**
-   * Retrieves the latest state root of the privacy pool from the entrypoint contract.
+   * Retrieves the current state root of the privacy pool.
    *
    * @param privacyPoolAddress - The address of the privacy pool contract.
-   * @returns The latest state root as a bigint.
+   * @returns The current state root as a bigint.
    */
   async getStateRoot(privacyPoolAddress: Address): Promise<bigint> {
     const stateRoot = await this.publicClient.readContract({
       address: privacyPoolAddress,
-      abi: IEntrypointABI as Abi,
+      abi: IPrivacyPoolABI as Abi,
       account: this.account,
-      functionName: "latestRoot",
+      functionName: "currentRoot",
     });
 
     return BigInt(stateRoot as string);

--- a/packages/sdk/test/unit/contracts.spec.ts
+++ b/packages/sdk/test/unit/contracts.spec.ts
@@ -5,6 +5,7 @@ import { Withdrawal, WithdrawalProof } from "../../src/types/withdrawal.js";
 import { CommitmentProof } from "../../src/types/commitment.js";
 import { ContractError } from "../../src/errors/base.error.js";
 import { Hash } from "../../src/types/commitment.js";
+import { IPrivacyPoolABI } from "../../src/abi/IPrivacyPool.js";
 
 const mockPublicClient = {
   simulateContract: vi.fn(),
@@ -227,6 +228,22 @@ describe("ContractInteractionsService", () => {
 
     await expect(service.getScopeData(BigInt(mockScope))).rejects.toThrow(
       ContractError.scopeNotFound(BigInt(mockScope)),
+    );
+  });
+
+  it("should get state root from the privacy pool currentRoot", async () => {
+    const expectedRoot = BigInt(123456789);
+    mockPublicClient.readContract.mockResolvedValue(expectedRoot);
+
+    const result = await service.getStateRoot(mockPoolAddress);
+
+    expect(result).toBe(expectedRoot);
+    expect(mockPublicClient.readContract).toHaveBeenCalledWith(
+      expect.objectContaining({
+        address: mockPoolAddress,
+        abi: IPrivacyPoolABI,
+        functionName: "currentRoot",
+      }),
     );
   });
 });


### PR DESCRIPTION
## Summary

This PR fixes an SDK correctness issue in `ContractInteractionsService.getStateRoot()`.

The SDK was calling Entrypoint `latestRoot()` with a pool address. That is not the pool state root used for withdrawal state validation. `latestRoot()` is the ASP root on Entrypoint, while the pool state root lives on the pool itself and is exposed through `currentRoot()`.

This PR switches `getStateRoot()` to read `currentRoot()` from the PrivacyPool ABI so the SDK returns the pool state root the protocol actually uses.

## Changes

- update `getStateRoot()` to call PrivacyPool `currentRoot()`
- add a unit test covering the correct ABI and function call
- bump the SDK version
- add a changelog entry for the fix

## Tests

Validated locally with:

- `yarn test --run test/unit/contracts.spec.ts`
- `yarn test`
- `yarn check-types`
- `yarn build`
- `yarn test:cov`