### PR TITLE
fix(sdk): getCommitment returns precommitment as nullifierHash

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- `getCommitment` and `BruteForceRecoveryService` now set `Commitment.nullifierHash` to `poseidon([nullifier])`, matching the docs, the `commitment.circom` circuit, and the pool's on-chain `nullifierHashes` spent marker (previously set to the precommitment hash `poseidon([nullifier, secret])`)
+
 ## [1.2.0] - 2026-03-18
 
 ### Fixed

--- a/packages/sdk/src/core/bruteForce.service.ts
+++ b/packages/sdk/src/core/bruteForce.service.ts
@@ -80,7 +80,7 @@ export class BruteForceRecoveryService {
           const preimage: CommitmentPreimage = { value, label, precommitment: basePrecommitment };
           const commitment: Commitment = {
             hash: computedHash,
-            nullifierHash: basePrecommitment.hash,
+            nullifierHash: poseidon([basePrecommitment.nullifier]) as Hash,
             preimage,
           };
 

--- a/packages/sdk/src/crypto.ts
+++ b/packages/sdk/src/crypto.ts
@@ -136,7 +136,7 @@ export function getCommitment(
 
   return {
     hash,
-    nullifierHash: precommitment.hash,
+    nullifierHash: poseidon([nullifier]) as Hash,
     preimage: {
       value,
       label,

--- a/packages/sdk/test/unit/bruteForce.spec.ts
+++ b/packages/sdk/test/unit/bruteForce.spec.ts
@@ -33,6 +33,10 @@ describe("BruteForceRecoveryService - Brute Force Recovery", () => {
         expect(result.success).toBe(true);
         expect(result.data).toHaveLength(1);
         expect(result.data?.[0]?.commitment.hash).toBe(expectedHash);
+        // nullifierHash must be Poseidon([nullifier]) (matches docs, circuit, and
+        // the pool's on-chain spent marker), not the precommitment hash.
+        expect(result.data?.[0]?.commitment.nullifierHash).toEqual(poseidon([precommitment.nullifier]));
+        expect(result.data?.[0]?.commitment.nullifierHash).not.toEqual(precommitment.hash);
     });
 
     it("should return NOT_FOUND when no matching commitment is found", async () => {

--- a/packages/sdk/test/unit/crypto.spec.ts
+++ b/packages/sdk/test/unit/crypto.spec.ts
@@ -46,6 +46,22 @@ describe("Crypto Utilities", () => {
       expect(commitment.preimage.label).toBe(label);
     });
 
+    it("sets nullifierHash to Poseidon([nullifier]) (matches docs, circuit, and on-chain spent marker)", () => {
+      const value = BigInt(1000);
+      const label = BigInt(42);
+      const nullifier = BigInt(123) as Secret;
+      const secret = BigInt(456) as Secret;
+
+      const commitment = getCommitment(value, label, nullifier, secret);
+
+      // docs/reference/sdk.md documents `nullifierHash` as "Hash of nullifier";
+      // circuits/commitment.circom computes `nullifierHash = Poseidon(1)(nullifier)`;
+      // the pool tracks spent notes by `nullifierHashes[poseidon([nullifier])]`.
+      expect(commitment.nullifierHash).toEqual(poseidon([nullifier]));
+      // It must NOT be the precommitment hash poseidon([nullifier, secret]).
+      expect(commitment.nullifierHash).not.toEqual(poseidon([nullifier, secret]));
+    });
+
     it("throws error for zero nullifier", () => {
       expect(() =>
         getCommitment(


### PR DESCRIPTION
## Problem
`getCommitment()` (packages/sdk/src/crypto.ts) sets `Commitment.nullifierHash`
to `precommitment.hash` = `poseidon([nullifier, secret])`. But everywhere else
`nullifierHash` is defined as `poseidon([nullifier])`:
- docs/reference/sdk.md: `nullifierHash: Hash // Hash of nullifier`
- docs/reference/circuits.md / docs/layers/zk/commitment.md: `Poseidon(nullifier)`
- circuits/commitment.circom: `Poseidon(1)(nullifier)`
- on-chain pool spent-marker `nullifierHashes` / `Withdrawn.spentNullifier`

Integrators reading `commitment.nullifierHash` for spent-detection (querying the
pool's `nullifierHashes` or scanning `Withdrawn.spentNullifier`) get false
negatives — spent notes appear spendable.

The same mislabel exists in `core/bruteForce.service.ts`.

## Impact
Integrator-facing only — the SDK internally recomputes the correct value
(account.service.ts), so no SDK functionality breaks and there's no fund-loss.

## Fix
Return `poseidon([nullifier])` in both places. Adds a regression test asserting
`getCommitment().nullifierHash === poseidon([nullifier])`. `yarn check-types`
clean; full SDK suite green.

If returning the precommitment here was intentional, happy to instead
rename/document the field (it duplicates `preimage.precommitment.hash`) — let me know.